### PR TITLE
2023.1 Solo Image Release

### DIFF
--- a/solo2/solo2.bash
+++ b/solo2/solo2.bash
@@ -71,9 +71,9 @@ rm /etc/yum.repos.d/solo2.repo
 dnf makecache
 
 #mutlinode stuff
-dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/flight-gather-0.0.7-1.el8.x86_64.rpm
+dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/flight-gather-0.0.8-1.el8.x86_64.rpm
 
-dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/flight-hunter-0.1.2-1.el8.x86_64.rpm
+dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/flight-hunter-0.2.1-1.el8.x86_64.rpm
 
 cat << EOF > /opt/flight/opt/hunter/etc/config.yml
 port: 8888

--- a/solo2/solo2.bash
+++ b/solo2/solo2.bash
@@ -185,20 +185,3 @@ merge_how:
 runcmd:
  - date +%s.%N | sha256sum | cut -c 1-40 > /opt/flight/etc/shared-secret.conf; chmod 0400 /opt/flight/etc/shared-secret.conf; /opt/flight/bin/flight service stack restart
 EOF
-
-#patch to fix issue in gnome-terminal under flight desktops
-if ( grep -q '8.' /etc/redhat-release ); then
-  cat << EOF > /tmp/fp1.patch
---- /opt/flight/usr/lib/desktop/types/gnome/session.sh.org	2022-08-26 11:20:43.000000000 +0000
-+++ /opt/flight/usr/lib/desktop/types/gnome/session.sh	2022-12-01 17:53:00.399328587 +0000
-@@ -164,6 +164,7 @@
-   gnome_terminal_pid=$!
- fi
-
-+export LANG=en_US.UTF-8
- gnome-session ${_GNOME_PARAMS} &
- gnome_session_pid=$!  
-EOF
-patch -p0 /tmp/fp1.patch
-rm /tmp/fp1.patch
-fi

--- a/solo2/solo2.bash
+++ b/solo2/solo2.bash
@@ -1,3 +1,7 @@
+# Version tag
+VERSION=flightsolo-2023.1
+echo $VERSION > /etc/solo-release
+
 #Repo
 cat << "EOF" > /etc/yum.repos.d/solo2.repo
 [openflight]

--- a/solo2/solo2.bash
+++ b/solo2/solo2.bash
@@ -76,13 +76,13 @@ dnf makecache
 #mutlinode stuff
 dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/flight-gather-0.0.8-1.el8.x86_64.rpm
 
-dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/flight-hunter-0.2.1-1.el8.x86_64.rpm
+dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/flight-hunter-0.3.0-1.el8.x86_64.rpm
 
 cat << EOF > /opt/flight/opt/hunter/etc/config.yml
 port: 8888
 autorun_mode: hunt
 include_self: true
-payload_file: /opt/flight/opt/gather/var/data.yml
+content_command: cat /opt/flight/opt/gather/var/data.yml
 auth_key: flight-solo
 EOF
 
@@ -111,8 +111,8 @@ EOF
 
 flight service enable hunter
 
-dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/flight-profile-0.1.1-1.el8.x86_64.rpm 
-dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/flight-profile-types-0.1.5-1.noarch.rpm
+dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/flight-profile-0.1.2-1.el8.x86_64.rpm 
+dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/flight-profile-types-0.1.6-1.noarch.rpm
 dnf -y install https://repo.openflighthpc.org/openflight/centos/8/x86_64/flight-pdsh-2.34-5.el8.x86_64.rpm
 
 flight profile prepare openflight-slurm-multinode

--- a/solo2/solo2.bash
+++ b/solo2/solo2.bash
@@ -1,6 +1,8 @@
 # Version tag
 VERSION=flightsolo-2023.1
-echo $VERSION > /etc/solo-release
+DATE="$(date +'%Y-%m-%d_%H-%M-%S')"
+BUILDVERSION="${VERSION}_${DATE}"
+echo $BUILDVERSION > /etc/solo-release
 
 #Repo
 cat << "EOF" > /etc/yum.repos.d/solo2.repo

--- a/solo2/solo2.bash
+++ b/solo2/solo2.bash
@@ -169,9 +169,6 @@ EOF
 
 systemctl daemon-reload
 
-# Remove desktop access_host things which break connecting via web-suite
-sed -i '4,9d' /opt/flight/usr/lib/profile/types/openflight-slurm-multinode/run_env/openflight-slurm-multinode/roles/flightenv/tasks/main.yml
-
 # Set title page for flight web apps (still defaults to openflightHPC)
 echo "document:" >> /opt/flight/opt/www/landing-page/branding/content/data/branding.yaml
 echo "  title: 'Flight Solo'" >> /opt/flight/opt/www/landing-page/branding/content/data/branding.yaml

--- a/solo2/solo2.bash
+++ b/solo2/solo2.bash
@@ -80,6 +80,7 @@ port: 8888
 autorun_mode: hunt
 include_self: true
 payload_file: /opt/flight/opt/gather/var/data.yml
+auth_key: flight-solo
 EOF
 
 firewall-offline-cmd --add-port 8888/tcp 

--- a/solo2/solo2.bash
+++ b/solo2/solo2.bash
@@ -169,11 +169,6 @@ EOF
 
 systemctl daemon-reload
 
-# Set title page for flight web apps (still defaults to openflightHPC)
-echo "document:" >> /opt/flight/opt/www/landing-page/branding/content/data/branding.yaml
-echo "  title: 'Flight Solo'" >> /opt/flight/opt/www/landing-page/branding/content/data/branding.yaml
-flight landing-page compile # just in case it needs to be recompiled here and isn't in the playbook as part of setup
-
 #remove key generated on rpm install and do it another way....
 rm -v /opt/flight/etc/shared-secret.conf
 cat << "EOF" > /etc/cloud/cloud.cfg.d/95_flightpatches.cfg

--- a/solo2/solo2.bash
+++ b/solo2/solo2.bash
@@ -112,7 +112,7 @@ EOF
 flight service enable hunter
 
 dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/flight-profile-0.1.1-1.el8.x86_64.rpm 
-dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/flight-profile-types-0.1.4-1.noarch.rpm
+dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/flight-profile-types-0.1.5-1.noarch.rpm
 dnf -y install https://repo.openflighthpc.org/openflight/centos/8/x86_64/flight-pdsh-2.34-5.el8.x86_64.rpm
 
 flight profile prepare openflight-slurm-multinode

--- a/solo2/solo2.bash
+++ b/solo2/solo2.bash
@@ -1,7 +1,7 @@
 # Version tag
-VERSION=flightsolo-2023.1
+VERSION=2023.1
 DATE="$(date +'%Y-%m-%d_%H-%M-%S')"
-BUILDVERSION="${VERSION}_${DATE}"
+BUILDVERSION="flightsolo-${VERSION}_${DATE}"
 echo $BUILDVERSION > /etc/solo-release
 
 #Repo
@@ -118,6 +118,11 @@ flight profile prepare openflight-kubernetes-multinode
 cat << EOF >> /opt/flight/opt/profile/etc/config.yml
 use_hunter: true
 EOF
+
+# Set release name & version in prompt
+sed -i 's/flight_STARTER_desc=.*/flight_STARTER_desc="an Alces Flight Solo HPC environment"/g' /opt/flight/etc/flight-starter.*
+sed -i 's/flight_STARTER_product=.*/flight_STARTER_product="Flight Solo"/g' /opt/flight/etc/flight-starter.*
+sed -i "s/flight_STARTER_release=.*/flight_STARTER_release='$VERSION'/g" /opt/flight/etc/flight-starter.*
 
 cat << 'EOF' > /usr/lib/systemd/system/flight-service.service
 # =============================================================================

--- a/solo2/solo2.bash
+++ b/solo2/solo2.bash
@@ -113,6 +113,7 @@ dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/fli
 dnf -y install https://repo.openflighthpc.org/openflight/centos/8/x86_64/flight-pdsh-2.34-5.el8.x86_64.rpm
 
 flight profile prepare openflight-slurm-multinode
+flight profile prepare openflight-kubernetes-multinode
 
 cat << EOF >> /opt/flight/opt/profile/etc/config.yml
 use_hunter: true

--- a/solo2/solo2.bash
+++ b/solo2/solo2.bash
@@ -109,7 +109,7 @@ EOF
 flight service enable hunter
 
 dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/flight-profile-0.1.1-1.el8.x86_64.rpm 
-dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/flight-profile-types-0.1.3-1.noarch.rpm
+dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/flight-profile-types-0.1.4-1.noarch.rpm
 dnf -y install https://repo.openflighthpc.org/openflight/centos/8/x86_64/flight-pdsh-2.34-5.el8.x86_64.rpm
 
 flight profile prepare openflight-slurm-multinode

--- a/solo2/solo2.bash
+++ b/solo2/solo2.bash
@@ -111,6 +111,7 @@ dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/fli
 dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/flight-profile-types-0.1.6-1.noarch.rpm
 dnf -y install https://repo.openflighthpc.org/openflight/centos/8/x86_64/flight-pdsh-2.34-5.el8.x86_64.rpm
 
+flight profile prepare openflight-slurm-standalone
 flight profile prepare openflight-slurm-multinode
 flight profile prepare openflight-kubernetes-multinode
 

--- a/solo2/solo2.bash
+++ b/solo2/solo2.bash
@@ -106,7 +106,7 @@ merge_how:
    settings: [no_replace, recurse_list]
 runcmd:
   - "IP=`ip route get 1.1.1.1 | awk '{ print $7 }'`; echo \"target_host: ${IP}\" >> /opt/flight/opt/hunter/etc/config.yml"
-  - if [ -f /opt/flight/cloudinit.in ]; then source /opt/flight/cloudinit.in ; /opt/flight/bin/flight hunter send  --server "${SERVER}" -f /opt/flight/opt/gather/var/data.yml; fi
+  - if [ -f /opt/flight/cloudinit.in ]; then source /opt/flight/cloudinit.in ; /opt/flight/bin/flight hunter send  --server "${SERVER}" -c 'cat /opt/flight/opt/gather/var/data.yml'; fi
 EOF
 
 flight service enable hunter

--- a/solo2/solo2.bash
+++ b/solo2/solo2.bash
@@ -55,9 +55,6 @@ EOF
 #allow generation of root user ssh keys
 sed -i 's/flight_SSH_LOWEST_UID=.*/flight_SSH_LOWEST_UID=0/g;s/flight_SSH_SKIP_USERS=.*/flight_SSH_SKIP_USERS="none"/g' /opt/flight/etc/setup-sshkey.rc
 
-#prepare the openflight-slurm-standalone spin
-flight profile prepare openflight-slurm-standalone
-
 echo "bg_image: /opt/flight/etc/assets/backgrounds/alces-flight.jpg" >> /opt/flight/opt/desktop/etc/config.yml
 
 #cloudinit overrides

--- a/solo2/solo2.bash
+++ b/solo2/solo2.bash
@@ -24,7 +24,7 @@ dnf -y install flight-user-suite
 dnf -y install flight-web-suite
 dnf -y install python3-websockify xorg-x11-apps netpbm-progs
 
-dnf -y install alces-flight-landing-page-branding
+dnf -y install https://alces-flight.s3.eu-west-1.amazonaws.com/repos/alces-flight-dev/centos/8/x86_64/alces-flight-landing-page-branding-1.7.1-1.el8.x86_64.rpm
 
 dnf -y install flight-plugin-system-systemd-service
 

--- a/solo2/solo2.bash
+++ b/solo2/solo2.bash
@@ -76,7 +76,7 @@ dnf makecache
 #mutlinode stuff
 dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/flight-gather-0.0.8-1.el8.x86_64.rpm
 
-dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/flight-hunter-0.3.0-1.el8.x86_64.rpm
+dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/flight-hunter-0.3.1-1.el8.x86_64.rpm
 
 cat << EOF > /opt/flight/opt/hunter/etc/config.yml
 port: 8888

--- a/solo2/solo2.bash
+++ b/solo2/solo2.bash
@@ -69,10 +69,6 @@ firewall-offline-cmd --add-port 5900-6000/tcp
 firewall-offline-cmd --add-service https
 firewall-offline-cmd --add-service http
 
-#Cleanup
-rm /etc/yum.repos.d/solo2.repo
-dnf makecache
-
 #mutlinode stuff
 dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/flight-gather-0.0.8-1.el8.x86_64.rpm
 
@@ -185,3 +181,7 @@ merge_how:
 runcmd:
  - date +%s.%N | sha256sum | cut -c 1-40 > /opt/flight/etc/shared-secret.conf; chmod 0400 /opt/flight/etc/shared-secret.conf; /opt/flight/bin/flight service stack restart
 EOF
+
+#Cleanup
+rm /etc/yum.repos.d/solo2.repo
+dnf makecache

--- a/solo2/solo2.bash
+++ b/solo2/solo2.bash
@@ -71,7 +71,7 @@ rm /etc/yum.repos.d/solo2.repo
 dnf makecache
 
 #mutlinode stuff
-dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/flight-gather-0.0.6-1.el8.x86_64.rpm
+dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/flight-gather-0.0.7-1.el8.x86_64.rpm
 
 dnf -y install https://repo.openflighthpc.org/openflight-dev/centos/8/x86_64/flight-hunter-0.1.2-1.el8.x86_64.rpm
 


### PR DESCRIPTION
This PR is for tracking & making changes relating to in-progress & upcoming changes to the image for the 2023.1 release.

Changelog:
- [x] Use latest Flight Gather version https://github.com/alces-flight/flight-image-customs/commit/747a5f243eabf77c513bf81145c2d36645050329
    - Fixes issue where machines with 0 GPUs would fail to gather any data 
    - Confirmed working by IK
- [x] Use latest Flight Hunter version https://github.com/alces-flight/flight-image-customs/commit/4d18c15a10f3341f6f8c753df9513ac7ca72c08b
    - Adds various new features and functionality to Flight Hunter (interactive naming, sending of prefixes/labels from clients, auth tokens to secure communication) 
- [x] Use latest Flight Profile Types & Multinode Playbook https://github.com/alces-flight/flight-image-customs/commit/42bd035df01ff9ee620635125558fca14852761e
    - Adds a pre-hook to Multinode build which means nodes can be added after initial profiling, adding more flexibility to cluster build process
    - Fixes issue with SLURM role to multiple compute nodes at once (_included once a new `flight profile prepare` is run for the type_)
    - Fixes issue manually repaired in script where desktop access_host needs to be removed (now removed in upstream playbook) https://github.com/alces-flight/flight-image-customs/commit/948235f345eba308b61de27ace585823ab18a3d0
    - Improves execution speed of multinode (Hunter MAC address parsing not required in both pre + post processing, now only done in pre) 
- [x] Use Latest Flight Desktop Types https://github.com/alces-flight/flight-image-customs/commit/50a0ab786a7dc905d34ca66ed1854485573e1a62
    - Fix issue with Gnome desktop sessions launched through Web Suite behaving strangely 
    - _New `flight-desktop-restapi` in prod repos will automatically include fix_
- [x] Kubernetes Profile Type https://github.com/alces-flight/flight-image-customs/commit/42bd035df01ff9ee620635125558fca14852761e
    - Playbook & profile changes now committed, awaiting testing and a decent test case to ensure Kubernetes works as expected (currently the inter-pod network seems a bit broken) 
- [x] Remove Web Suite Page Titling https://github.com/alces-flight/flight-image-customs/commit/b973ebe93d91aee379ab75eb94c4c37bff3341ed
    - Dependant on acceptance & release of package as result of https://github.com/openflighthpc/flight-landing-page/pull/21
- [x] Add Build Version to `/etc/` 

Once changes are implemented the initial image will need to go through the testing process before releasing to marketplace. 